### PR TITLE
Feat/slack formbricks bridge

### DIFF
--- a/apps/web/app/(app)/environments/[environmentId]/integrations/slack/AddIntegrationModal.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/integrations/slack/AddIntegrationModal.tsx
@@ -1,0 +1,308 @@
+import { TSurvey } from "@formbricks/types/v1/surveys";
+import { TSlackChannel, TSlackConfigData, TSlackIntegration } from "@formbricks/types/v1/integrations";
+import { Button, Checkbox, Label } from "@formbricks/ui";
+import SlackLogo from "@/images/slacklogo.png";
+import { useState, useEffect } from "react";
+import { useForm } from "react-hook-form";
+import toast from "react-hot-toast";
+import Image from "next/image";
+import Modal from "@/components/shared/Modal";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { ChevronDownIcon } from "@heroicons/react/24/solid";
+import { upsertIntegrationAction } from "@/app/(app)/environments/[environmentId]/integrations/slack/actions";
+
+interface AddWebhookModalProps {
+  environmentId: string;
+  open: boolean;
+  surveys: TSurvey[];
+  setOpen: (v: boolean) => void;
+  channels: TSlackChannel[];
+  slackIntegration: TSlackIntegration;
+  selectedIntegration?: (TSlackConfigData & { index: number }) | null;
+}
+
+export default function AddSlackConnectionModal({
+  environmentId,
+  surveys,
+  open,
+  setOpen,
+  channels,
+  slackIntegration,
+  selectedIntegration,
+}: AddWebhookModalProps) {
+  const { handleSubmit } = useForm();
+
+  const integrationData = {
+    channelId: "",
+    channelName: "",
+    surveyId: "",
+    surveyName: "",
+    questionIds: [""],
+    questions: "",
+    createdAt: new Date(),
+  };
+
+  const [selectedQuestions, setSelectedQuestions] = useState<string[]>([]);
+  const [isLinkingSheet, setIsLinkingSheet] = useState(false);
+  const [selectedSurvey, setSelectedSurvey] = useState<TSurvey | null>(null);
+  const [selectedChannel, setSelectedChannel] = useState<TSlackChannel | null>(null);
+  const [isDeleting, setIsDeleting] = useState<any>(null);
+  const existingIntegrationData = slackIntegration?.config?.data;
+  const slackIntegrationData: Partial<TSlackIntegration> = {
+    type: "slack",
+    config: {
+      key: slackIntegration?.config?.key,
+      user: slackIntegration.config.user,
+      data: existingIntegrationData || [],
+    },
+  };
+
+  useEffect(() => {
+    if (selectedSurvey) {
+      const questionIds = selectedSurvey.questions.map((question) => question.id);
+      if (!selectedIntegration) {
+        setSelectedQuestions(questionIds);
+      }
+    }
+  }, [selectedIntegration, selectedSurvey]);
+
+  useEffect(() => {
+    if (selectedIntegration) {
+      setSelectedChannel({
+        id: selectedIntegration.channelId,
+        name: selectedIntegration.channelName,
+      });
+      setSelectedSurvey(
+        surveys.find((survey) => {
+          return survey.id === selectedIntegration.surveyId;
+        })!
+      );
+      setSelectedQuestions(selectedIntegration.questionIds);
+      return;
+    }
+    resetForm();
+  }, [selectedIntegration, surveys]);
+
+  const linkSheet = async () => {
+    try {
+      if (!selectedChannel) {
+        throw new Error("Please select a slack channel");
+      }
+      if (!selectedSurvey) {
+        throw new Error("Please select a survey");
+      }
+
+      if (selectedQuestions.length === 0) {
+        throw new Error("Please select at least one question");
+      }
+      setIsLinkingSheet(true);
+      integrationData.channelId = selectedChannel.id;
+      integrationData.channelName = selectedChannel.name;
+      integrationData.surveyId = selectedSurvey.id;
+      integrationData.surveyName = selectedSurvey.name;
+      integrationData.questionIds = selectedQuestions;
+      integrationData.questions =
+        selectedQuestions.length === selectedSurvey?.questions.length
+          ? "All questions"
+          : "Selected questions";
+      integrationData.createdAt = new Date();
+      if (selectedIntegration) {
+        // update action
+        slackIntegrationData.config!.data[selectedIntegration.index] = integrationData;
+      } else {
+        // create action
+        slackIntegrationData.config!.data.push(integrationData);
+      }
+      await upsertIntegrationAction(environmentId, slackIntegrationData);
+      toast.success(`Integration ${selectedIntegration ? "updated" : "added"} successfully`);
+      resetForm();
+      setOpen(false);
+    } catch (e) {
+      toast.error(e.message);
+    } finally {
+      setIsLinkingSheet(false);
+    }
+  };
+
+  const handleCheckboxChange = (questionId: string) => {
+    setSelectedQuestions((prevValues) =>
+      prevValues.includes(questionId)
+        ? prevValues.filter((value) => value !== questionId)
+        : [...prevValues, questionId]
+    );
+  };
+
+  const setOpenWithStates = (isOpen: boolean) => {
+    setOpen(isOpen);
+  };
+
+  const resetForm = () => {
+    setIsLinkingSheet(false);
+    setSelectedChannel(null);
+    setSelectedSurvey(null);
+  };
+
+  const deleteLink = async () => {
+    slackIntegrationData.config!.data.splice(selectedIntegration!.index, 1);
+    try {
+      setIsDeleting(true);
+      await upsertIntegrationAction(environmentId, slackIntegrationData);
+      toast.success("Integration removed successfully");
+      setOpen(false);
+    } catch (error) {
+      toast.error(error.message);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const DropdownSelector = ({ label, items, selectedItem, setSelectedItem, disabled }) => {
+    return (
+      <div className="col-span-1">
+        <Label htmlFor={label}>{label}</Label>
+        <div className="mt-1 flex">
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <button
+                disabled={disabled ? disabled : false}
+                type="button"
+                className="flex h-10 w-full rounded-md border border-slate-300 bg-transparent px-3 py-2 text-sm text-slate-800 placeholder:text-slate-400 focus:outline-none disabled:cursor-not-allowed disabled:opacity-50 dark:border-slate-500 dark:text-slate-300">
+                <span className="flex flex-1">
+                  <span>{selectedItem ? selectedItem.name : `${label}`}</span>
+                </span>
+                <span className="flex h-full items-center border-l pl-3">
+                  <ChevronDownIcon className="h-4 w-4 text-gray-500" />
+                </span>
+              </button>
+            </DropdownMenu.Trigger>
+
+            {!disabled && (
+              <DropdownMenu.Portal>
+                <DropdownMenu.Content
+                  className="z-50 min-w-[220px] rounded-md bg-white text-sm text-slate-800 shadow-md"
+                  align="start">
+                  {items &&
+                    items.map((item) => (
+                      <DropdownMenu.Item
+                        key={item.id}
+                        className="flex cursor-pointer items-center p-3 hover:bg-gray-100 hover:outline-none data-[disabled]:cursor-default data-[disabled]:opacity-50"
+                        onSelect={() => setSelectedItem(item)}>
+                        {item.name}
+                      </DropdownMenu.Item>
+                    ))}
+                </DropdownMenu.Content>
+              </DropdownMenu.Portal>
+            )}
+          </DropdownMenu.Root>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <Modal open={open} setOpen={setOpenWithStates} noPadding closeOnOutsideClick={false}>
+      <div className="flex h-full flex-col rounded-lg">
+        <div className="rounded-t-lg bg-slate-100">
+          <div className="flex w-full items-center justify-between p-6">
+            <div className="flex items-center space-x-2">
+              <div className="mr-1.5 h-6 w-6 text-slate-500">
+                <Image className="w-12" src={SlackLogo} alt="Slack logo" />
+              </div>
+              <div>
+                <div className="text-xl font-medium text-slate-700">Link Slack Channel</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <form onSubmit={handleSubmit(linkSheet)}>
+          <div className="flex justify-between rounded-lg p-6">
+            <div className="w-full space-y-4">
+              <div>
+                <div className="mb-4">
+                  <DropdownSelector
+                    label="Select Channel"
+                    items={channels}
+                    selectedItem={selectedChannel}
+                    setSelectedItem={setSelectedChannel}
+                    disabled={channels.length === 0}
+                  />
+                  <p className="m-1 text-xs text-slate-500">
+                    {channels.length === 0 &&
+                      "You have to create at least one channel to be able to setup this integration"}
+                  </p>
+                </div>
+                <div>
+                  <DropdownSelector
+                    label="Select Survey"
+                    items={surveys}
+                    selectedItem={selectedSurvey}
+                    setSelectedItem={setSelectedSurvey}
+                    disabled={surveys.length === 0}
+                  />
+                  <p className="m-1 text-xs text-slate-500">
+                    {surveys.length === 0 &&
+                      "You have to create a survey to be able to setup this integration"}
+                  </p>
+                </div>
+              </div>
+              {selectedSurvey && (
+                <div>
+                  <Label htmlFor="Surveys">Questions</Label>
+                  <div className="mt-1 rounded-lg border border-slate-200">
+                    <div className="grid content-center rounded-lg bg-slate-50 p-3 text-left text-sm text-slate-900">
+                      {selectedSurvey?.questions.map((question) => (
+                        <div key={question.id} className="my-1 flex items-center space-x-2">
+                          <label htmlFor={question.id} className="flex cursor-pointer items-center">
+                            <Checkbox
+                              type="button"
+                              id={question.id}
+                              value={question.id}
+                              className="bg-white"
+                              checked={selectedQuestions.includes(question.id)}
+                              onCheckedChange={() => {
+                                handleCheckboxChange(question.id);
+                              }}
+                            />
+                            <span className="ml-2">{question.headline}</span>
+                          </label>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+          <div className="flex justify-end border-t border-slate-200 p-6">
+            <div className="flex space-x-2">
+              {selectedIntegration ? (
+                <Button
+                  type="button"
+                  variant="warn"
+                  loading={isDeleting}
+                  onClick={() => {
+                    deleteLink();
+                  }}>
+                  Delete
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  variant="minimal"
+                  onClick={() => {
+                    setOpen(false);
+                    resetForm();
+                  }}>
+                  Cancel
+                </Button>
+              )}
+              <Button variant="darkCTA" type="submit" loading={isLinkingSheet}>
+                {selectedIntegration ? "Update" : "Link Channel"}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </Modal>
+  );
+}

--- a/apps/web/app/(app)/environments/[environmentId]/integrations/slack/SlackWrapper.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/integrations/slack/SlackWrapper.tsx
@@ -1,26 +1,28 @@
 "use client";
 
+import AddSlackConnectionModal from "@/app/(app)/environments/[environmentId]/integrations/slack/AddIntegrationModal";
 import Connect from "@/app/(app)/environments/[environmentId]/integrations/slack/Connect";
 import Home from "@/app/(app)/environments/[environmentId]/integrations/slack/Home";
 import { TEnvironment } from "@formbricks/types/v1/environment";
-import { TSlackConfigData, TSlackIntegration } from "@formbricks/types/v1/integrations";
+import { TSlackChannel, TSlackConfigData, TSlackIntegration } from "@formbricks/types/v1/integrations";
 import { TSurvey } from "@formbricks/types/v1/surveys";
 import { useState } from "react";
-
 interface SlackWrapperProps {
   enabled: boolean;
   environment: TEnvironment;
   surveys: TSurvey[];
+  channels: TSlackChannel[];
   environmentId: string;
   slackIntegration: TSlackIntegration | undefined;
   webAppUrl: string;
 }
 
-export default async function SlackWrapper({
+export default function SlackWrapper({
   enabled,
   environment,
   environmentId,
   surveys,
+  channels,
   slackIntegration,
   webAppUrl,
 }: SlackWrapperProps) {
@@ -35,14 +37,25 @@ export default async function SlackWrapper({
   };
 
   return isConnected && slackIntegration ? (
-    <Home
-      environment={environment}
-      slackIntegration={slackIntegration}
-      setOpenAddIntegrationModal={setModalOpen}
-      setIsConnected={setIsConnected}
-      setSelectedIntegration={setSelectedIntegration}
-      refreshSheet={refreshSheet}
-    />
+    <>
+      <AddSlackConnectionModal
+        environmentId={environment.id}
+        surveys={surveys}
+        open={isModalOpen}
+        setOpen={setModalOpen}
+        channels={channels}
+        slackIntegration={slackIntegration}
+        selectedIntegration={selectedIntegration}
+      />
+      <Home
+        environment={environment}
+        slackIntegration={slackIntegration}
+        setOpenAddIntegrationModal={setModalOpen}
+        setIsConnected={setIsConnected}
+        setSelectedIntegration={setSelectedIntegration}
+        refreshSheet={refreshSheet}
+      />
+    </>
   ) : (
     <Connect enabled={enabled} environmentId={environmentId} webAppUrl={webAppUrl} />
   );

--- a/apps/web/app/(app)/environments/[environmentId]/integrations/slack/actions.ts
+++ b/apps/web/app/(app)/environments/[environmentId]/integrations/slack/actions.ts
@@ -1,0 +1,20 @@
+"use server";
+
+import { getSpreadSheets } from "@formbricks/lib/googleSheet/service";
+import { createOrUpdateIntegration, deleteIntegration } from "@formbricks/lib/integration/service";
+import { TSlackIntegration } from "@formbricks/types/v1/integrations";
+
+export async function upsertIntegrationAction(
+  environmentId: string,
+  integrationData: Partial<TSlackIntegration>
+) {
+  return await createOrUpdateIntegration(environmentId, integrationData);
+}
+
+export async function deleteIntegrationAction(integrationId: string) {
+  return await deleteIntegration(integrationId);
+}
+
+export async function refreshSheetAction(environmentId: string) {
+  return await getSpreadSheets(environmentId);
+}

--- a/apps/web/app/(app)/environments/[environmentId]/integrations/slack/page.tsx
+++ b/apps/web/app/(app)/environments/[environmentId]/integrations/slack/page.tsx
@@ -2,8 +2,9 @@ import GoBackButton from "@/components/shared/GoBackButton";
 import { getIntegrations } from "@formbricks/lib/integration/service";
 import { getSurveys } from "@formbricks/lib/survey/service";
 import { getEnvironment } from "@formbricks/lib/environment/service";
+import { getSlackChannels } from "@formbricks/lib/slack/service";
 import { SLACK_CLIENT_ID, SLACK_CLIENT_SECRET, WEBAPP_URL } from "@formbricks/lib/constants";
-import { TSlackConfigData, TSlackIntegration } from "@formbricks/types/v1/integrations";
+import { TSlackChannel, TSlackIntegration } from "@formbricks/types/v1/integrations";
 import SlackWrapper from "@/app/(app)/environments/[environmentId]/integrations/slack/SlackWrapper";
 
 export default async function Slack({ params }) {
@@ -19,6 +20,11 @@ export default async function Slack({ params }) {
     (integration): integration is TSlackIntegration => integration.type === "slack"
   );
 
+  let channelArray: TSlackChannel[] = [];
+  if (slackIntegration && slackIntegration.config.key) {
+    channelArray = await getSlackChannels(params.environmentId);
+  }
+
   if (!environment) {
     throw new Error("Environment not found");
   }
@@ -30,6 +36,7 @@ export default async function Slack({ params }) {
         <SlackWrapper
           enabled={enabled}
           environment={environment}
+          channels={channelArray}
           surveys={surveys}
           slackIntegration={slackIntegration}
           webAppUrl={WEBAPP_URL}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "clean": "rimraf .turbo node_modules .next",
     "dev": "next dev --experimental-https",
-    "go": "next dev",
+    "go": "next dev --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/packages/lib/slack/service.ts
+++ b/packages/lib/slack/service.ts
@@ -1,0 +1,73 @@
+import { DatabaseError } from "@formbricks/types/v1/errors";
+import { TSlackChannel, TSlackCredential, TSlackIntegration } from "@formbricks/types/v1/integrations";
+import { Prisma } from "@prisma/client";
+import { prisma } from "@formbricks/database";
+import { cache } from "react";
+
+export const fetchChannels = async (key: TSlackCredential): Promise<TSlackChannel[]> => {
+  const response = await fetch("https://slack.com/api/conversations.list", {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${key.access_token}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error("Network response was not ok");
+  }
+
+  const data = await response.json();
+
+  if (!data.ok) {
+    throw new Error(data.error);
+  }
+
+  return data.channels.map((channel: { name: string; id: string }) => ({
+    name: channel.name,
+    id: channel.id,
+  }));
+};
+
+export const getSlackChannels = async (environmentId: string): Promise<TSlackChannel[]> => {
+  let channels: TSlackChannel[] = [];
+  try {
+    const slackIntegration = await getSlackIntegration(environmentId);
+    if (slackIntegration && slackIntegration.config?.key) {
+      channels = await fetchChannels(slackIntegration.config.key);
+    }
+    return channels;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError("Database operation failed");
+    }
+    throw error;
+  }
+};
+
+export const getSlackIntegration = cache(async (environmentId: string): Promise<TSlackIntegration | null> => {
+  try {
+    const result = await prisma.integration.findUnique({
+      where: {
+        type_environmentId: {
+          environmentId,
+          type: "slack",
+        },
+      },
+    });
+    // Type Guard
+    if (result && isSlackIntegration(result)) {
+      return result as TSlackIntegration; // Explicit casting
+    }
+    return null;
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new DatabaseError("Database operation failed");
+    }
+    throw error;
+  }
+});
+
+function isSlackIntegration(integration: any): integration is TSlackIntegration {
+  return integration.type === "slack";
+}

--- a/packages/types/v1/integrations.ts
+++ b/packages/types/v1/integrations.ts
@@ -24,6 +24,11 @@ export const ZSlackConfigData = z.object({
   channelName: z.string(),
 });
 
+export const ZSlackChannel = z.object({
+  name: z.string(),
+  id: z.string(),
+});
+
 export const ZSlackUser = z.object({
   id: z.string(),
   name: z.string(),
@@ -120,6 +125,7 @@ export type TSlackConfig = z.infer<typeof ZSlackConfig>;
 export type TSlackConfigData = z.infer<typeof ZSlackConfigData>;
 export type TSlackIntegration = z.infer<typeof ZSlackIntegration>;
 export type TSlackUser = z.infer<typeof ZSlackUser>;
+export type TSlackChannel = z.infer<typeof ZSlackChannel>;
 
 // ================ Placeholder Integration Types ============================
 export type TPlaceHolderIntegration = z.infer<typeof ZPlaceHolderIntegration>;


### PR DESCRIPTION
Actually the reason we had to dig deep into the above, is because **NEXT-AUTH uses Openid and the scopes for slack doesn't work for the openid actually**, so for fetching the channels the token we were using was invalid, and from there this story starts of **How can we get NEXT AUTH to use slack authorization api's instead of the existing open id APIs, which made us fetch the code -> access_token -> user** and finally persist all the data that we are getting.

Anyways, we persist the data now and we have the `Many-to-Many`, Channel - Survey details. I had to introduce a migration as well for this to happen and also introduces some new types out of the integrations and also have added the slack service provider for fetching services. I plan to use these services to beautify the formbricks updates in order to beautify the slack messages before it gets passed on to the slack messages. So, that our messages are more fun and formbrickcy. We are working on it and I'm glad to say it's the last part, then YAAAYYY!! we will have a one way, formbricks -> slack integration. Attached a video for. your referemce. I will make a pull request soon and update you both <@522403894274293770> & <@841720682718953493>. Here is the branch, we are using as base for creation of the slack app, you can have a look https://github.com/Palanikannan1437/formbricks/tree/feat/slack-app
